### PR TITLE
更新工作流

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,10 +2,7 @@ name: Deploy VitePress GitHub Pages
 
 on:
   push:
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Fetch Upstream Data"]
-    types: [ completed ]
+  workflow_dispatch: 
 
 # 设置 GITHUB_TOKEN 的权限，以允许部署到 GitHub Pages
 permissions:

--- a/.github/workflows/fetch-upstream-data.yaml
+++ b/.github/workflows/fetch-upstream-data.yaml
@@ -40,6 +40,6 @@ jobs:
             echo "没有检测到文件变化"
           else
             echo "检测到文件变化，正在提交..."
-            git commit -m "chore: update repository data [skip ci]"
+            git commit -m "chore: update repository data"
             git push
           fi


### PR DESCRIPTION
rt，之前沒有觸發部署的原因是 `[skip ci]`

Copilot’s summary

This pull request makes minor adjustments to the GitHub Actions workflows for deployment and data fetching. The changes simplify the deployment trigger logic and update the commit message format for upstream data updates.

Workflow configuration updates:

* Removed the `workflow_run` trigger for the `Deploy VitePress GitHub Pages` workflow, so it no longer runs automatically after the `Fetch Upstream Data` workflow completes. (`.github/workflows/deploy.yaml`)

Commit message update:

* Changed the commit message in the `fetch-upstream-data.yaml` workflow to remove the `[skip ci]` flag when committing repository data updates. (`.github/workflows/fetch-upstream-data.yaml`)