### PR TITLE
fix: fix avatar URL parameter handling and run prebuild before dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"scripts": {
 		"ng": "ng",
-		"dev": "vite",
+		"dev": "bun run prebuild && vite",
 		"start": "bun run dev",
 		"prebuild": "bun scripts/generate-doc-updates.ts && bun scripts/generate-doc-nav.ts",
 		"build": "vite build",

--- a/src/app/features/home/contributors.ts
+++ b/src/app/features/home/contributors.ts
@@ -53,7 +53,7 @@ interface ContributorsData {
                   rel="noopener noreferrer"
                   class="contributor-item"
                 >
-                  <img [src]="c.avatar + '?size=80'" [alt]="c.name" class="contributor-avatar" />
+                  <img [src]="c.avatar + '&size=40'" [alt]="c.name" class="contributor-avatar" />
                   <span class="contributor-name">{{ c.name }}</span>
                 </a>
               }

--- a/src/app/pages/docs/[...slug].page.ts
+++ b/src/app/pages/docs/[...slug].page.ts
@@ -309,7 +309,7 @@ export default class DocContentComponent implements OnDestroy {
 			.map((author, index) => {
 				const safeAuthor = this.escapeHtml(author);
 				const encodedAuthor = encodeURIComponent(author);
-				return `<a class="doc-author" href="https://github.com/${encodedAuthor}" target="_blank" rel="noopener noreferrer" title="${safeAuthor}" style="--author-index: ${index}"><img src="https://github.com/${encodedAuthor}.png&size=40" alt="${safeAuthor}" loading="lazy" width="40" height="40" /></a>`;
+				return `<a class="doc-author" href="https://github.com/${encodedAuthor}" target="_blank" rel="noopener noreferrer" title="${safeAuthor}" style="--author-index: ${index}"><img src="https://github.com/${encodedAuthor}.png?size=40" alt="${safeAuthor}" loading="lazy" width="40" height="40" /></a>`;
 			})
 			.join("");
 

--- a/src/app/pages/docs/[...slug].page.ts
+++ b/src/app/pages/docs/[...slug].page.ts
@@ -309,7 +309,7 @@ export default class DocContentComponent implements OnDestroy {
 			.map((author, index) => {
 				const safeAuthor = this.escapeHtml(author);
 				const encodedAuthor = encodeURIComponent(author);
-				return `<a class="doc-author" href="https://github.com/${encodedAuthor}" target="_blank" rel="noopener noreferrer" title="${safeAuthor}" style="--author-index: ${index}"><img src="https://github.com/${encodedAuthor}.png?size=40" alt="${safeAuthor}" loading="lazy" width="40" height="40" /></a>`;
+				return `<a class="doc-author" href="https://github.com/${encodedAuthor}" target="_blank" rel="noopener noreferrer" title="${safeAuthor}" style="--author-index: ${index}"><img src="https://github.com/${encodedAuthor}.png&size=40" alt="${safeAuthor}" loading="lazy" width="40" height="40" /></a>`;
 			})
 			.join("");
 


### PR DESCRIPTION
This pull request introduces improvements to the development workflow and makes consistent adjustments to how contributor and author avatar images are loaded. The main changes include updating the `dev` script to ensure documentation is prebuilt before starting the development server, and standardizing the avatar image URLs to use the `&size=40` parameter for consistent sizing.

**Development workflow improvements:**

* Updated the `dev` script in `package.json` to run the `prebuild` step before starting Vite, ensuring documentation is generated before development begins.

**Avatar image URL standardization:**

* Changed the avatar image URL in the contributors list to use `&size=40` instead of `?size=80`, ensuring consistent image sizing. (`src/app/features/home/contributors.ts`)
* Updated the author avatar image URL in the documentation page to use `&size=40` instead of `?size=40`, aligning with the new URL convention. (`src/app/pages/docs/[...slug].page.ts`) ([src/app/pages/docs/[...slug].page.tsL312-R312](diffhunk://#diff-afb4ec17c4f441eb617b4c99887e321e29b737138b2347c525a9aee11f8f3060L312-R312))